### PR TITLE
lock for thread safety + configurable sleep

### DIFF
--- a/tests/config.nims
+++ b/tests/config.nims
@@ -1,1 +1,2 @@
 switch("path", "$projectDir/../src")
+--mm: orc


### PR DESCRIPTION
Currently crashes at runtime with refc when multithreading with no error messages. I don't know if that's acceptable, but I assume orc should be the favored mm.